### PR TITLE
fix issue in L1C IW processor

### DIFF
--- a/slcl1butils/compute/compute_from_l1b.py
+++ b/slcl1butils/compute/compute_from_l1b.py
@@ -52,8 +52,13 @@ def compute_xs_from_l1b(_file, burst_type='intra', time_separation='2tau'):
                 xsIm = xsIm.mean(dim=['1tau'])
 
     elif burst_type == 'inter':
-        xsRe = ds['xspectra_Re']  # +1j*ds_inter['xspectra_Im']
-        xsIm = ds['xspectra_Im']
+        if 'xspectra_Re' in ds:
+            xsRe = ds['xspectra_Re']  # +1j*ds_inter['xspectra_Im']
+            xsIm = ds['xspectra_Im']
+        else:
+            logging.warning('xspectra_Re absent from interburst group')
+            xsRe = None
+            xsIm = None
     else:  # WV case
         raise Exception('not handle case')
     if xsRe is None:


### PR DESCRIPTION
handle case where L1B intergroup doesnt contain xspectra_Re nor xspectra_Im.
So far, the proessing was crashing with :

```python
Traceback (most recent call last):
  File "/home/datawork-cersat-public/project/mpc-sentinel1/workspace/mamba/envs/l1bprocmars23/bin/do_IW_L1C_SAFE_from_L1B_SAFE", line 8, in <module>
    sys.exit(main())
  File "/home/datawork-cersat-public/cache/project/mpc-sentinel1/workspace/mamba/envs/l1bprocmars23/lib/python3.10/site-packages/slcl1butils/scripts/do_IW_L1C_SAFE_from_L1B_SAFE.py", line 309, in main
    do_L1C_SAFE_from_L1B_SAFE(args.l1bsafe,version=args.version,outputdir=args.outputdir, cwave=True, macs=True, colocat=True,
  File "/home/datawork-cersat-public/cache/project/mpc-sentinel1/workspace/mamba/envs/l1bprocmars23/lib/python3.10/site-packages/slcl1butils/scripts/do_IW_L1C_SAFE_from_L1B_SAFE.py", line 87, in do_L1C_SAFE_from_L1B_SAFE
    ds_intra, ds_inter = enrich_onesubswath_l1b(l1b_fullpath, ancillary_list=ancillary_list, cwave=cwave, macs=macs,
  File "/home/datawork-cersat-public/cache/project/mpc-sentinel1/workspace/mamba/envs/l1bprocmars23/lib/python3.10/site-packages/slcl1butils/scripts/do_IW_L1C_SAFE_from_L1B_SAFE.py", line 118, in enrich_onesubswath_l1b
    xs_inter, ds_inter = compute_xs_from_l1b(l1b_fullpath, burst_type=burst_type, time_separation=time_separation)
  File "/home/datawork-cersat-public/cache/project/mpc-sentinel1/workspace/mamba/envs/l1bprocmars23/lib/python3.10/site-packages/slcl1butils/compute/compute_from_l1b.py", line 55, in compute_xs_from_l1b
    xsRe = ds['xspectra_Re']  # +1j*ds_inter['xspectra_Im']
  File "/home/datawork-cersat-public/cache/project/mpc-sentinel1/workspace/mamba/envs/l1bprocmars23/lib/python3.10/site-packages/xarray/core/dataset.py", line 1438, in __getitem__
    return self._construct_dataarray(key)
  File "/home/datawork-cersat-public/cache/project/mpc-sentinel1/workspace/mamba/envs/l1bprocmars23/lib/python3.10/site-packages/xarray/core/dataset.py", line 1349, in _construct_dataarray
    _, name, variable = _get_virtual_variable(self._variables, name, self.dims)
  File "/home/datawork-cersat-public/cache/project/mpc-sentinel1/workspace/mamba/envs/l1bprocmars23/lib/python3.10/site-packages/xarray/core/dataset.py", line 185, in _get_virtual_variable
    raise KeyError(key)
KeyError: 'xspectra_Re'
```

with this PR, only a warning will be issued in stdout:

```
WARNING compute_from_l1b.py(59) xspectra_Re absent from interburst group
```

And is there is no xspectra -> no CWAVE -> no IMACS -> thus there will be no L1C .nc file saved.

```python
there is no xspectra in this subswath -> the L1C will not be saved
```

