### PR TITLE
fix issue related to inconsistant number of tiles along azimuth and interpolation of ancillary fields

### DIFF
--- a/docs/examples/do_L1C_SAFE_from_L1B_SAFE_example.ipynb
+++ b/docs/examples/do_L1C_SAFE_from_L1B_SAFE_example.ipynb
@@ -47,14 +47,17 @@
    },
    "outputs": [],
    "source": [
-    "#l1bncfile_pattern = os.path.abspath('../../assests/*IW*SAFE')\n",
-    "\n",
-    "#print(l1bncfile_pattern)\n",
-    "#lst = glob(l1bncfile_pattern)\n",
     "one_safe_l1b = get_test_file('S1B_IW_XSP__1SDV_20211026T045709_20211026T045736_029302_037F35_1CD7.SAFE')\n",
-    "#full_safe_files = lst[0]\n",
-    "#full_safe_files\n",
     "one_safe_l1b"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "conf['iw_outputdir']"
    ]
   },
   {
@@ -73,7 +76,7 @@
     "    print('===')\n",
     "    print(os.path.basename(full_safe_file))\n",
     "    print('===')\n",
-    "    ret = do_L1C_SAFE_from_L1B_SAFE(full_safe_file,version=version,outputdir=conf['iw_outputdir'])\n",
+    "    ret = do_L1C_SAFE_from_L1B_SAFE(full_safe_file,version=version,outputdir=conf['iw_outputdir'],dev=True)\n",
     "            "
    ]
   }
@@ -94,7 +97,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.15"
+   "version": "3.10.8"
   }
  },
  "nbformat": 4,

--- a/slcl1butils/compute/compute_from_l1b.py
+++ b/slcl1butils/compute/compute_from_l1b.py
@@ -32,7 +32,7 @@ def compute_xs_from_l1b(_file, burst_type='intra', time_separation='2tau'):
     # ds = dt[burst_type+'burst_xspectra'].to_dataset()
     # drop variables
 
-    logging.info('time_separation : %s', time_separation)
+    logging.debug('time_separation : %s', time_separation)
     if burst_type == 'intra':
         consolidated_list = []
         list_to_drop = ['var_xspectra_0tau', 'var_xspectra_1tau', 'var_xspectra_2tau']


### PR DESCRIPTION
- [x] fix #39 
- [x] reduce logs and have details about ancillary fields added or not
- [x] processing L1B -> L1C tested for IW and WV 
- [x] test sphinx doc generation `make html` with committed code

forensic: investigations and bug fix dev/test have been done here `debug_L1C_ancillary_fields_resampling.ipynb`.
Origin of the problem
for one burst 5 tiles
for the last burst 4 tiles
![image](https://github.com/umr-lops/utils_xsarslc_l1b/assets/14925067/401eaba5-ae7a-44de-9f91-8ac76ba543bc)

then we get lon/lat in sar L1B dataset that is NaN (and it is nominal).
the workaround is to use `xarray.interp_na()` at the interpolation of ancillary field step.

it has been tested on
 - IW L1B that was in error
 - IW L1B that was working properly
 - WV L1B
And for each case the ancillary variables are correctly field (no NaN expect when it is land for WW3).