### PR TITLE
remove `distutils` 

### DIFF
--- a/ci/requirements/docs.yaml
+++ b/ci/requirements/docs.yaml
@@ -18,6 +18,5 @@ dependencies:
   - holoviews
   - geoviews
   - fsspec
-  - distutils
   - pip:
     - -e ../..

--- a/ci/requirements/environment.yaml
+++ b/ci/requirements/environment.yaml
@@ -11,7 +11,6 @@ dependencies:
   - isort
   - black
   - dask-labextension
-  - distutils
   # testing
   - pytest
   - pytest-reportlog

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,6 @@ classifiers = [
     "Programming Language :: Python :: 3",
 ]
 dependencies = [
-    'distutils',
     'PyYAML',
     "xarray",
     "numpy",


### PR DESCRIPTION
remove `distutils` to follow https://peps.python.org/pep-0632/#migratin-advice and because `distutils` was absent from the package