### PR TITLE
no matplotlib-base in PyPi -> back to matplotlib

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     'tqdm',
     "zarr",
     'fsspec',
-    'matplotlib-base',
+    'matplotlib',
     'scipy',
     'aiohttp',
     'holoviews',


### PR DESCRIPTION
to fix issue in conda-forge docker build.